### PR TITLE
Fixing new alarm button

### DIFF
--- a/panic/widgets.py
+++ b/panic/widgets.py
@@ -111,7 +111,10 @@ class AlarmValueLabel(Qt.QLabel):#TaurusValueLabel):
             
     def updateStyle(self,extra=''):
         self.setAlignment(QtCore.Qt.AlignCenter)
-        obj = self.alarm #obj = self.getModelValueObj()
+        if hasattr(self, 'alarm'): 
+            obj = self.alarm 
+        else:
+	    obj = {}
         #print('AlarmValueLabel.updateStyle(%s,%s)'%(type(obj),obj))
         if hasattr(obj,'active'):
             value = obj.active


### PR DESCRIPTION
The `New alarm` button was not working, since there is no `alarm` object in the widget yet. The fix is assigning  a dummy dict object.