### PR TITLE
Enbling -r option for mail

### DIFF
--- a/panic/ds/PyAlarm.py
+++ b/panic/ds/PyAlarm.py
@@ -2307,7 +2307,8 @@ class PyAlarm(PyTango.Device_4Impl, fandango.log.Logger):
                 command = 'echo -e "'+format4sendmail(argin[0])+'" '
                 command += '| mail -s "%s" ' % argin[1]
                 command += '-S from=%s ' % self.FromAddress 
-                #'-r %s ' % (self.FromAddress)
+                if len(self.MailDashRoption) > 0:
+                    command += '-r %s ' % (self.MailDashRoption)
                 command += (argin[2] if isString(argin[2]) 
                                       else ','.join(argin[2]))
                 self.info( 'Launching mail command: '

--- a/panic/properties.py
+++ b/panic/properties.py
@@ -141,6 +141,10 @@ PANIC_PROPERTIES = {
         [PyTango.DevString,
          "mail or smtp[:host[:port]]",
          [ "mail" ] ],
+    'MailDashRoption':
+        [PyTango.DevString,
+         "If not empty, adds -r oprtion to the mail command with its value. Usefull to avoid 'sender address rejected' when sending from local domains.",
+         [ "" ] ],
     'FromAddress':
         [PyTango.DevString,
         "Address that will appear as Sender in mail and SMS",


### PR DESCRIPTION
It appears that, in certain setups (like at Solaris), to make mails sent by PyAlarm being accepted by receivers mail servers it requires proper "reply-to" setting which can be solved via usage of `-r` option.